### PR TITLE
fix sample test, wrap window usage in document check

### DIFF
--- a/loader/loader.js
+++ b/loader/loader.js
@@ -1,4 +1,9 @@
-const dicomParser = window.dicomParser;
+
+if (typeof document != 'undefined') {
+    const dicomParser = window.dicomParser;
+}
+
+
 import { dicomTagDictionary } from '../tagDictionary/dictionary.js';
 
 export function readFile(file) {

--- a/loader/loader.js
+++ b/loader/loader.js
@@ -1,6 +1,9 @@
 
+let dicomParser;
 if (typeof document != 'undefined') {
-    const dicomParser = window.dicomParser;
+    dicomParser = window.dicomParser;
+} else {
+    dicomParser = "undefined";
 }
 
 


### PR DESCRIPTION
## Issue
Sample test for Qunit fails

## Fix
Code was trying to interact with the window, which doesn't exist in node, where the test are running.
Added check for document, if it's undefined then skip interacting with window

## Future
Need to do more research on how to better handle differences between running code in browser vs node