### PR TITLE
remove file location selection, save log messages in memory and downl…

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -19,48 +19,48 @@ services:
     #         - "7900:7900"
     #     shm_size: 2g
 
-    python:
-        image: python:latest
-        volumes:
-            - ..:/usr/app
-        tty: true
-        stdin_open: true
-        command: bash
+    # python:
+    #     image: python:latest
+    #     volumes:
+    #         - ..:/usr/app
+    #     tty: true
+    #     stdin_open: true
+    #     command: bash
 
-    chrome:
-        image: selenium/node-chrome:4.28.1-20250123
-        shm_size: 2gb
-        depends_on:
-            - selenium-hub
-        environment:
-            - SE_EVENT_BUS_HOST=selenium-hub
-            - SE_EVENT_BUS_PUBLISH_PORT=4442
-            - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+    # chrome:
+    #     image: selenium/node-chrome:4.28.1-20250123
+    #     shm_size: 2gb
+    #     depends_on:
+    #         - selenium-hub
+    #     environment:
+    #         - SE_EVENT_BUS_HOST=selenium-hub
+    #         - SE_EVENT_BUS_PUBLISH_PORT=4442
+    #         - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
 
-    edge:
-        image: selenium/node-edge:4.28.1-20250123
-        shm_size: 2gb
-        depends_on:
-            - selenium-hub
-        environment:
-            - SE_EVENT_BUS_HOST=selenium-hub
-            - SE_EVENT_BUS_PUBLISH_PORT=4442
-            - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+    # edge:
+    #     image: selenium/node-edge:4.28.1-20250123
+    #     shm_size: 2gb
+    #     depends_on:
+    #         - selenium-hub
+    #     environment:
+    #         - SE_EVENT_BUS_HOST=selenium-hub
+    #         - SE_EVENT_BUS_PUBLISH_PORT=4442
+    #         - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
 
-    firefox:
-        image: selenium/node-firefox:4.28.1-20250123
-        shm_size: 2gb
-        depends_on:
-            - selenium-hub
-        environment:
-            - SE_EVENT_BUS_HOST=selenium-hub
-            - SE_EVENT_BUS_PUBLISH_PORT=4442
-            - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+    # firefox:
+    #     image: selenium/node-firefox:4.28.1-20250123
+    #     shm_size: 2gb
+    #     depends_on:
+    #         - selenium-hub
+    #     environment:
+    #         - SE_EVENT_BUS_HOST=selenium-hub
+    #         - SE_EVENT_BUS_PUBLISH_PORT=4442
+    #         - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
 
-    selenium-hub:
-        image: selenium/hub:4.28.1-20250123
-        container_name: selenium-hub
-        ports:
-            - "4442:4442"
-            - "4443:4443"
-            - "4444:4444"
+    # selenium-hub:
+    #     image: selenium/hub:4.28.1-20250123
+    #     container_name: selenium-hub
+    #     ports:
+    #         - "4442:4442"
+    #         - "4443:4443"
+    #         - "4444:4444"

--- a/index.html
+++ b/index.html
@@ -63,8 +63,7 @@
 
         <footer>
             <div>University of Saskatchewan - CMPT 371 Team 2 Project</div>
-            <button id="log-file-picker">Log Location</button>
-            <button id="log-file-close">Save Log</button>
+            <button id="log-file-save">Save Log</button>
         </footer>
 
         <script

--- a/logger/logger.js
+++ b/logger/logger.js
@@ -12,51 +12,31 @@ export class Logger {
     /**
      * Constructor for the Logger class
      * @constructor
-     * @param {string} handle - The file handle to write log messages to
      * @param {string} postUrl - The URL to post log messages to
      */
-    constructor(handle, postUrl) {
-        this.handle = handle || null
+    constructor(postUrl) {
+        this.logData = []
         this.postUrl =
             postUrl ||
             "https://us-central1-data-a9e6d.cloudfunctions.net/app/add/msg"
     }
 
     /**
-     * Set the file handle to write log messages to
-     */
-    async pickHandle() {
-        this.handle = await window.showSaveFilePicker()
-        this.writableStream = await this.handle.createWritable()
-    }
-
-    /**
      * Write a log message to the local file
      * @param {string} level - The log level of the message
      * @param {string} message - The message to log
-     * @returns {Promise} - A promise that resolves when the message is written
+     * @returns {void} - No return value
      */
     async localLog(level, message) {
-        if (this.handle == null) {
-            console.log("No local log file set")
-        } else {
-            try {
-                await this.writableStream.write(
-                    JSON.stringify(`{${level}: ${message}}`) + ",\n"
-                )
-            } catch (err) {
-                console.error(err.name, err.message)
-            }
-        }
+        this.logData.push("\n" + JSON.stringify(`{ ${level}: ${message}, Date: ${new Date().toISOString()}, UserAgent: ${userAgent} }`)  ) 
     }
 
     /**
-     * Close the local log file
-     * @returns {Promise} - A promise that resolves when the file is closed
+     * Get the log data
+     * @returns {Array} - The log data
      */
-    async closeFile() {
-        await this.writableStream.close()
-        console.log("close log file")
+    getLog() {
+        return this.logData
     }
 
     /**

--- a/script.js
+++ b/script.js
@@ -88,11 +88,20 @@ if (typeof document != "undefined") {
     document.addEventListener("DOMContentLoaded", () => {
         setupFileUpload()
     })
+ 
+    document.getElementById("log-file-save").addEventListener("click", () => {
+        let logData = logger.getLog()
 
-    document.getElementById("log-file-picker").addEventListener("click", () => {
-        logger.pickHandle()
+        const blob = new Blob([logData], { type: 'application/json' });
+
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'log_' + new Date().toISOString() + '.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
     })
-    document.getElementById("log-file-close").addEventListener("click", () => {
-        logger.closeFile()
-    })
+
 }

--- a/tests/test_runner.html
+++ b/tests/test_runner.html
@@ -30,8 +30,7 @@
         <div id="dicom-tags" style="display: none;"></div>
         <div id="loading-text"></div>
         <button id="sidebarCollapse"></button>
-        <button id="log-file-picker"></button>
-        <button id="log-file-close"></button>
+        <button id="log-file-save"></button>
     </div>
 
     <script>

--- a/tests/uitests.spec.js
+++ b/tests/uitests.spec.js
@@ -146,10 +146,8 @@ test('Log buttons mock test', async({ page })=> {
   await page.goto('/');
 
   // Test if the button is present and can be clicked
-  await expect(page.locator('#log-file-picker')).toBeVisible();
-  await page.locator('#log-file-picker').click();
-  await expect(page.locator('#log-file-close')).toBeVisible();
-  await page.locator('#log-file-close').click();
+  await expect(page.locator('#log-file-save')).toBeVisible();
+  await page.locator('#log-file-save').click();
 
   // TODO: test if filechooser is opened by the log button. Currently playwright doesn't support testing window.showSaveFilePicker()
 });


### PR DESCRIPTION
## Feature
Remove file selector for local log file
Save log messages in memory and download log file with save file

## Fix
Previously used file selector api wasn't supported in firefox, updated save method will work all browsers

## Testing
Manually tested, change should allow for auto testing, old method wasn't possible to test with playwright

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] Tests available? 
- [x] Verify meets function requirements?

Kanban ticket number and link
closes #69 