### PR TITLE
fix: theme icon starts with system default theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -161,6 +161,7 @@ const App: React.FC = () => {
                 sidebarButtonRef={sidebarButtonRef}
                 onInstallClick={handleInstallClick}
                 showInstallButton={!!deferredPrompt}
+                currTheme={theme}
             />
 
             <div className="flex flex-1">

--- a/src/components/Navigation/ThemeSelector.tsx
+++ b/src/components/Navigation/ThemeSelector.tsx
@@ -9,12 +9,16 @@ import { ThemeSelectorProps } from "../../types/types";
  */
 export const ThemeSelector: React.FC<ThemeSelectorProps> = ({
     toggleTheme,
+    currTheme
 }) => {
     return (
         <label className="swap swap-rotate transition-all duration-500 hover:text-accent">
             <input type="checkbox" onChange={toggleTheme} />
-            <SunIcon className="swap-off size-6" />
-            <MoonIcon className="swap-on size-6" />
+            {currTheme === "night" ? (
+                <SunIcon className="size-6" />
+            ) : (
+                <MoonIcon className="size-6" />
+            )}
         </label>
     );
 };

--- a/src/components/Navigation/Topbar.tsx
+++ b/src/components/Navigation/Topbar.tsx
@@ -18,7 +18,8 @@ const Topbar: React.FC<TopbarProps> = ({
     toggleTheme, 
     sidebarButtonRef,
     onInstallClick,
-    showInstallButton 
+    showInstallButton,
+    currTheme
 }) => {
     return (
         <div className="sticky top-0 z-20 w-full backdrop-blur-sm bg-base-100/80 shadow-md">
@@ -36,7 +37,7 @@ const Topbar: React.FC<TopbarProps> = ({
                             Install App
                         </button>
                     )}
-                    <ThemeSelector toggleTheme={toggleTheme} />
+                    <ThemeSelector toggleTheme={toggleTheme} currTheme={currTheme}/>
                     <button
                         ref={sidebarButtonRef}
                         onClick={toggleSidebar}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -155,9 +155,11 @@ export interface IconButtonProps {
 /**
  * interface ThemeSelectorProps
  * @param toggleTheme - Function to toggle theme
+ * @param currTheme - Current theme
  */
 export interface ThemeSelectorProps {
     toggleTheme: (e: any) => void;
+    currTheme: string;
 }
 
 /**
@@ -180,6 +182,7 @@ export interface GenButtonProps {
  * @param sidebarButtonRef - Ref for the sidebar toggle button
  * @param onInstallClick - Function to handle install click
  * @param showInstallButton - Boolean to determine if install button is shown
+ * @param currTheme - Current theme
  */
 export interface TopbarProps {
     toggleSidebar: () => void;
@@ -188,6 +191,7 @@ export interface TopbarProps {
     sidebarButtonRef: React.MutableRefObject<HTMLButtonElement | null>;
     onInstallClick: () => void;
     showInstallButton: boolean;
+    currTheme: string;
 }
 
 /**


### PR DESCRIPTION
## Issue
Theme icon always started as "sunIcon" so if the user's system default was "day", they have to click twice to switch to the night theme.

## Fix
Added a conditional to theme selector to pick between sun or moon icon depending on the state "theme" in App.tsx. Adjusted ThemeSelector and TopBar props in types.ts accordingly.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] Tests available? 
- [ ] Any unintended results? (if so, documented? Other fixes in progress? Tickets created?)