### PR TITLE
Tested DicomParserUtils 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ entirely in the browser, using **React**, **Vite**, **TailwindCSS**, and
   tags.
 - **PWAs (Progressive Web Apps)**: Enabling offline use and improved
   performance.
+- **Jest**: JavaScript/Typescript testing framework, works well with React. Used here for 
+   unit/integration type testing.
+- **Playwright**: End-to-End functional UI testing framework, automates browser interactions.
 
 ## Installation
 
@@ -68,6 +71,18 @@ Edge) to use the editor.
     ```
 5. Open your browser and go to `http://localhost:5173` to start using the DICOM
    tag editor.
+
+### For testers
+
+Once test files are made in your branch:
+
+1. Install the dependencies:
+    ```bash
+    npm install
+    ```
+2. Run all tests:
+    ```bash
+    npm test
 
 ### Docker Container
 

--- a/tests/jest/DicomParserUtils.test.tsx
+++ b/tests/jest/DicomParserUtils.test.tsx
@@ -1,0 +1,37 @@
+import { parseDicomFile } from "../../src/components/DicomData/DicomParserUtils";
+import dicomParser from "dicom-parser";
+import { jest } from "@jest/globals";
+
+// Mock dicomParser
+jest.mock("dicom-parser", () => ({
+    parseDicom: jest.fn(),
+}));
+
+describe("DicomParserUtils", () => {
+    let mockFile: File;
+
+    beforeEach(() => {
+        // Create a mock DICOM file
+        mockFile = new File([new ArrayBuffer(10)], "test.dcm", {
+            type: "application/dicom",
+        });
+    });
+
+    /***** UNIT-INTEGRATION TEST: Should call dicomParser and extract tags *****/
+    test("calls dicomParser.parseDicom when file is valid", async () => {
+        const mockDataset = {
+            elements: {
+                X00100010: { vr: "PN" }, // Patient Name
+            },
+            string: jest.fn(() => "John Doe"),
+        };
+
+        (dicomParser.parseDicom as jest.Mock).mockReturnValue(mockDataset);
+
+        const result = await parseDicomFile(mockFile);
+
+        expect(dicomParser.parseDicom).toHaveBeenCalled();
+        expect(result["X00100010"].value).toBe("John Doe");
+    });
+
+});

--- a/tests/jest/DicomParserUtils.test.tsx
+++ b/tests/jest/DicomParserUtils.test.tsx
@@ -109,7 +109,7 @@ describe("DicomParserUtils", () => {
         expect(result["X00100010"].value).toBe("John Doe");
     });
 
-    /***** UNIT-INTEGRATION TEST: Should handle nested sequence items *****/
+    /***** UNIT-INTEGRATION TEST: Should extract nested sequence items correctly *****/
     test("extracts nested DICOM sequence (SQ) items", async () => {
         const mockDataset = {
             elements: {
@@ -149,6 +149,31 @@ describe("DicomParserUtils", () => {
         // Ensure sequence (0040A730) extracts nested tag Id's correctly
         expect(result["0040A730"].value["00080100"].tagId).toBe("00080100");
         expect(result["0040A730"].value["00080102"].tagId).toBe("00080102");
+    });
+
+    /***** UNIT-INTEGRATION TEST: extract values from multiple DICOM tags *****/
+    test("extracts values from multiple DICOM tags", async () => {
+        const mockDataset = {
+            elements: {
+                X00100010: { vr: "PN" }, // Patient Name
+                X00100020: { vr: "LO" }, // Patient ID
+                X00100030: { vr: "DA" }, // Patient Birth Date
+            },
+            string: jest.fn((tag) => {
+                if (tag === "X00100010") return "Aladin Alihodzic";
+                if (tag === "X00100020") return "101010";
+                if (tag === "X00100030") return "19960309";
+                return "N/A";
+            }),
+        };
+
+        (dicomParser.parseDicom as jest.Mock).mockReturnValue(mockDataset);
+
+        const result = await parseDicomFile(mockFile);
+
+        expect(result["X00100010"].value).toBe("Aladin Alihodzic");
+        expect(result["X00100020"].value).toBe("101010");
+        expect(result["X00100030"].value).toBe("19960309");
     });
 
 });

--- a/tests/jest/DicomParserUtils.test.tsx
+++ b/tests/jest/DicomParserUtils.test.tsx
@@ -63,6 +63,24 @@ describe("DicomParserUtils", () => {
             .rejects.toEqual("File reading error occurred.");
     
         mockFileReader.mockRestore();
-    });    
+    });
+    
+    /***** UNIT-INTEGRATION TEST: extract hidden DICOM tags *****/
+    test("extracts hidden DICOM tags correctly", async () => {
+        const mockDataset = {
+            elements: {
+                X0025101B: { vr: "UI" }, // Hidden Tag
+                X00100010: { vr: "PN" }, // Not a hidden Tag
+            },
+            string: jest.fn((tag) => (tag === "X00100010" ? "John Doe" : "Hidden Value")),
+        };
+
+        (dicomParser.parseDicom as jest.Mock).mockReturnValue(mockDataset);
+
+        const result = await parseDicomFile(mockFile);
+
+        expect(result["X0025101B"].hidden).toBe(true);
+        expect(result["X00100010"].value).toBe("John Doe");
+    });
 
 });

--- a/tests/jest/DicomParserUtils.test.tsx
+++ b/tests/jest/DicomParserUtils.test.tsx
@@ -34,4 +34,14 @@ describe("DicomParserUtils", () => {
         expect(result["X00100010"].value).toBe("John Doe");
     });
 
+     /***** UNIT TEST: Should reject on parsing errors *****/
+     test("rejects if dicomParser throws an error", async () => {
+        (dicomParser.parseDicom as jest.Mock).mockImplementation(() => {
+            throw new Error("Parsing Error");
+        });
+
+        await expect(parseDicomFile(mockFile))
+            .rejects.toEqual("Error parsing DICOM file: Error: Parsing Error");
+    });
+
 });

--- a/tests/jest/DicomParserUtils.test.tsx
+++ b/tests/jest/DicomParserUtils.test.tsx
@@ -44,4 +44,25 @@ describe("DicomParserUtils", () => {
             .rejects.toEqual("Error parsing DICOM file: Error: Parsing Error");
     });
 
+    /***** UNIT TEST: Should reject on file reading error *****/
+    test("rejects if FileReader encounters an error", async () => {
+        const mockFileReader = jest.spyOn(global, "FileReader").mockImplementation(() => {
+            // Simulates FileReader API calls with error event
+            const fileReaderInstance = {
+                onerror: null as ((event: Event) => void) | null, // Ensure correct typing
+                readAsArrayBuffer: jest.fn(() => {
+                    if (fileReaderInstance.onerror) {
+                        fileReaderInstance.onerror(new Event("error")); // Trigger error event
+                    }
+                }),
+            };
+            return fileReaderInstance as unknown as FileReader;
+        });
+    
+        await expect(parseDicomFile(mockFile))
+            .rejects.toEqual("File reading error occurred.");
+    
+        mockFileReader.mockRestore();
+    });    
+
 });


### PR DESCRIPTION
Tested DicomParserUtils.tsx :

UNIT-INTEGRATION TEST: Should call dicomParser and extract tags
UNIT TEST: Should reject on parsing errors
UNIT TEST: Should reject on file reading error
UNIT-INTEGRATION TEST: extract hidden DICOM tags correctly
UNIT-INTEGRATION TEST: Should extract nested sequence items correctly
UNIT-INTEGRATION TEST: extract values from multiple DICOM tags

added testing documentation to README