### PR TITLE
Fix: Display double and uint16 tag values correctly

### DIFF
--- a/src/components/DicomData/DicomParserUtils.tsx
+++ b/src/components/DicomData/DicomParserUtils.tsx
@@ -84,7 +84,9 @@ const extractDicomTags = (dataSet: any) => {
                 break;
             case "FD":
                 value = dataSet.double(tag).toString() || "N/A";
-                console.log("FD: ", value);
+                break;
+            case "US":
+                value = dataSet.uint16(tag).toString() || "N/A";
                 break;
             default:
                 value = dataSet.string(tag) || "N/A";

--- a/src/components/DicomData/DicomParserUtils.tsx
+++ b/src/components/DicomData/DicomParserUtils.tsx
@@ -56,8 +56,12 @@ const extractDicomTags = (dataSet: any) => {
     Object.keys(dataSet.elements).forEach((tag: any) => {
         const element = dataSet.elements[tag];
         const tagId = tag.toUpperCase();
-        const tagName = tagDictionary.lookup(tagId) || "Unknown Tag";
-        const vr = element.vr;
+        const tagName = tagDictionary.lookupTagName(tagId) || "Unknown Tag";
+        let vr = element.vr;
+        const vrTagDict = tagDictionary.lookupTagVR(tagId);
+        if(!vr) {       // If VR is not found, use the VR from the dictionary
+            vr = vrTagDict;
+        }
 
         let value: any;
 
@@ -77,6 +81,10 @@ const extractDicomTags = (dataSet: any) => {
                         element.dataOffset + element.length
                     )
                     .toString();
+                break;
+            case "FD":
+                value = dataSet.double(tag).toString() || "N/A";
+                console.log("FD: ", value);
                 break;
             default:
                 value = dataSet.string(tag) || "N/A";

--- a/src/tagDictionary/dictionary.tsx
+++ b/src/tagDictionary/dictionary.tsx
@@ -16,11 +16,11 @@ export class TagDictionary {
     }
 
     /**
-     * lookup - Look up the name of a DICOM tag from its tag number
+     * lookupTagName - Look up the name of a DICOM tag from its tag number
      * @param {string} tag
      * @returns {string} The name of the DICOM tag or Unknown if not found
      */
-    lookup(tag: string): string {
+    lookupTagName(tag: string): string {
         let tagName: string;
         try {
             tagName = this.dicomTagDictionary[tag.slice(1)].name;
@@ -29,5 +29,21 @@ export class TagDictionary {
         }
 
         return tagName;
+    }
+
+    /**
+     * lookupTagVR - Look up the VR (Value Representation) of a DICOM tag from its tag number
+     * @param {string} tag
+     * @returns {string} The VR of the DICOM tag or Unknown if not found
+     */
+    lookupTagVR(tag: string): string {
+        let tagVR: string;
+        try {
+            tagVR = this.dicomTagDictionary[tag.slice(1)].vr;
+        } catch {
+            tagVR = "Unknown";
+        }
+
+        return tagVR;
     }
 }


### PR DESCRIPTION
## Issue
Double and uint16 tag values were displayed incorrectly

## Fix
dicom-parser did not output VR for all dicom tags correctly. Many were returned as undefined. So, used tag name to lookup VR in tag dictionary instead, if VR is returned as undefined by parseDicom. Then, used VR to figure out if its a double or uint16 tag value.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] Tests available?
- [ ] Any unintended results? (if so, documented? Other fixes in progress? Tickets created?)
   - Did a manual cross check by comparing sample dicoms in microDicom viewer. Did not seem like any other values were messed up