### PR TITLE
fixed tiny bug on editing mode

### DIFF
--- a/src/components/FileHandling/FileTable.tsx
+++ b/src/components/FileHandling/FileTable.tsx
@@ -54,7 +54,7 @@ const FileTable: React.FC<FileTableProps> = ({
                 isOpen={isModalOpen}
                 onClose={() => setIsModalOpen(false)}
                 title="Cannot Select File"
-                text="When editing individually, only one file can be edited at a time."
+                text="When editing as a series, only one file can be edited at a time."
             />
         </div>
     );

--- a/src/components/FileHandling/FileTableBody.tsx
+++ b/src/components/FileHandling/FileTableBody.tsx
@@ -23,8 +23,8 @@ const FileTableBody: React.FC<FileListProps> = ({
                     key={index}
                     onClick={
                         !series
-                            ? () => onFileSelect(index)
-                            : () => openModal(true)
+                            ? () => openModal(true) 
+                            : () => onFileSelect(index)
                     }
                     className={`group cursor-pointer transition-all hover:bg-primary/5 ${
                         index === currentFileIndex ? "bg-primary/10" : ""

--- a/src/components/FileHandling/FileTableBody.tsx
+++ b/src/components/FileHandling/FileTableBody.tsx
@@ -23,8 +23,8 @@ const FileTableBody: React.FC<FileListProps> = ({
                     key={index}
                     onClick={
                         !series
-                            ? () => openModal(true) 
-                            : () => onFileSelect(index)
+                            ? () => onFileSelect(index)
+                            : () => openModal(true)  
                     }
                     className={`group cursor-pointer transition-all hover:bg-primary/5 ${
                         index === currentFileIndex ? "bg-primary/10" : ""


### PR DESCRIPTION

## Issue
Super tiny bug on the editing mode, when it's editing as series, it pops up only one file can be selected

## Fix
just reversed two lines :  ? () => openModal(true)    in filetablebody
                                        : () => onFileSelect(index)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] Tests available? 
- [ ] Any unintended results? no 

Manually tested