### PR TITLE
Refinement: Changed save button label

### DIFF
--- a/src/components/DicomData/TableComponents/TableControls.tsx
+++ b/src/components/DicomData/TableComponents/TableControls.tsx
@@ -23,7 +23,7 @@ const TableControls: React.FC<TableControlsProps> = ({
         <Search searchTerm={searchTerm} onSearchChange={onSearchChange} />
         <div className="ml-4">
             <GenButton
-                label="Save Single File Edits"
+                label="Download File"
                 disabled={false}
                 onClick={onSave}
             />

--- a/tests/jest/DicomTable.test.tsx
+++ b/tests/jest/DicomTable.test.tsx
@@ -70,7 +70,7 @@ describe("DicomTable Component", () => {
             );
         });
         expect(screen.getByText(/DICOM Tags/i)).toBeInTheDocument();
-        expect(screen.getByText(/Save Single File Edits/i)).toBeInTheDocument();
+        expect(screen.getByText(/Download File/i)).toBeInTheDocument();
     });
 
     // broken test
@@ -147,7 +147,7 @@ describe("DicomTable Component", () => {
     //         />
     //     );
 
-    //     const updateButton = screen.getByText(/Save Single File Edits/i);
+    //     const updateButton = screen.getByText(/Download File/i);
     //     fireEvent.click(updateButton);
 
     //     await waitFor(() => {
@@ -166,7 +166,7 @@ describe("DicomTable Component", () => {
     //         />
     //     );
 
-    //     const updateButton = screen.getByText(/Save Single File Edits/i);
+    //     const updateButton = screen.getByText(/Download File/i);
     //     fireEvent.click(updateButton);
 
     //     await waitFor(() => {

--- a/tests/playwright/example.spec.ts
+++ b/tests/playwright/example.spec.ts
@@ -63,7 +63,7 @@ test("Edit a DICOM tag and save changes", async ({ page }) => {
 
     // Save changes
     const saveButton = page.getByRole("button", {
-        name: "Save Single File Edits",
+        name: "Download File",
     });
     await expect(saveButton).toBeEnabled();
     await saveButton.click();
@@ -433,7 +433,7 @@ test("Updating file by navigating through side bar", async ({ page }) => {
 
     // Save changes
     const saveButton = page.getByRole("button", {
-        name: "Save Single File Edits",
+        name: "Download File",
     });
     await expect(saveButton).toBeEnabled();
     await saveButton.click();


### PR DESCRIPTION
## Issue
Wording "Save Single file Edits" was slightly ambiguous as it downloaded the new updated file instead of just save.

## Fix
Changed label to "Download File". Also changed the playwright and jest tests to match the new label change.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests available? 
- [ ] Any unintended results? (if so, documented? Other fixes in progress? Tickets created?)

Both playwright and jest tests (with the new label name) pass.