### PR TITLE
Fix/safari multifile download

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,6 +1,12 @@
-FROM node:latest
+FROM node:23-bullseye
 
 WORKDIR /app
+
+# playwright dependencies
+RUN npx playwright install-deps
+
+# install playwright
+RUN npx playwright install
 
 # enter with bash, so we can run commands ie npm install, 
 # use npm run dev to start dev server

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 
 services:
     web:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "loglevel": "^1.9.2",
         "loglevel-plugin-remote": "^0.6.8",
         "react": "^19.0.0",
+        "react-device-detect": "^2.2.3",
         "react-dom": "^19.0.0",
         "react-dropzone": "^14.3.5",
         "react-tooltip": "^5.28.0",
@@ -10395,6 +10396,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "license": "MIT",
+      "dependencies": {
+        "ua-parser-js": "^1.0.33"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
@@ -12115,6 +12129,32 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.8.0"
+      }
+    },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "loglevel": "^1.9.2",
     "loglevel-plugin-remote": "^0.6.8",
     "react": "^19.0.0",
+    "react-device-detect": "^2.2.3",
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.5",
     "react-tooltip": "^5.28.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview",
     "docs": "typedoc --entryPointStrategy Expand src",
     "test": "jest",
+    "playwright": "playwright test",
     "install:pydicom": "pip install -r requirements-dev.txt",
     "postinstall": "node -e \"if (process.env.NODE_ENV !== 'production') { require('child_process').execSync('npm run install:pydicom', { stdio: 'inherit' }); }\""
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
     testDir: "./tests/playwright",
@@ -10,9 +10,32 @@ export default defineConfig({
         reuseExistingServer: !process.env.CI, // Avoids duplicate servers in local runs
         timeout: 120000,
     },
-    use: {
-        baseURL: "http://localhost:5173",
-        headless: true,
-        browserName: "firefox",
-    },
+    projects: [
+        {
+            name: "firefox",
+            use: {
+                baseURL: "http://localhost:5173",
+                headless: true,
+                browserName: "firefox",
+            },
+        },
+        // comment out the following browsers due to failing safari test, issue noted
+        // {
+        //     name: "webkit",
+        //     use: {
+        //         baseURL: "http://localhost:5173",
+        //         headless: true,
+        //         browserName: "webkit",
+        //         ...devices["Desktop Safari"],
+        //     },
+        // },
+        // {
+        //     name: "chromium",
+        //     use: {
+        //         baseURL: "http://localhost:5173",
+        //         headless: true,
+        //         browserName: "chromium",
+        //     },
+        // },
+    ]
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
+import { isSafari } from "react-device-detect";
 import Sidebar from "./components/Navigation/Sidebar";
 import Topbar from "./components/Navigation/Topbar";
 import FileUploader from "./components/FileHandling/FileUploader";
@@ -39,7 +40,7 @@ const App: React.FC = () => {
     const [seriesSwitchModel, setSeriesSwitchModel] = useState(false);
 
     const [downloadOption, setDownloadOption] = useState<string>(
-        localStorage.getItem("downloadOption") ?? "single"
+        isSafari ? "zip" : localStorage.getItem("downloadOption") ?? "single"
     );
 
     const [theme, setTheme] = useState(

--- a/src/components/utils/DownloadOption.tsx
+++ b/src/components/utils/DownloadOption.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Tooltip } from "react-tooltip";
+import { isSafari } from "react-device-detect";
 
 interface DownloadOptionProps {
     setDownloadOption: (value: string) => void;
@@ -10,7 +11,13 @@ const DownloadOption: React.FC<DownloadOptionProps> = ({
     setDownloadOption,
     downloadOption,
 }) => {
+    const safari = isSafari;
+
     const handleChange = (event: any) => {
+        if (safari) {
+            // Safari does not support downloading multiple files at once
+            return;
+        }
         if (event.target.checked) setDownloadOption("zip");
         else setDownloadOption("single");
     };
@@ -26,6 +33,7 @@ const DownloadOption: React.FC<DownloadOptionProps> = ({
                     onChange={handleChange}
                     data-tooltip-id="download-option-button-tooltip"
                     data-tooltip-content={
+                        safari ? "Not supported in Safari" :
                         downloadOption === "zip"
                             ? "Switch to Individual Files"
                             : "Switch to Zip File"

--- a/tests/playwright/safari.test.ts
+++ b/tests/playwright/safari.test.ts
@@ -1,0 +1,111 @@
+import { test, expect, chromium, webkit } from '@playwright/test';
+
+/**
+ * Test that in Safari, the download option cannot be changed.
+ * and in non-Safari browsers, the download option can be changed.
+ */
+test.describe('Safari DownloadOption Component', () => {
+    test('should not allow changing download option for Safari', async () => {
+        // Launch the Safari (webkit) browser
+        const browser = await webkit.launch();
+
+        const context = await browser.newContext();
+        await context.clearCookies();   
+
+        const page = await browser.newPage();
+        await page.goto('http://localhost:5173'); 
+
+        // clear any saved downloadOption in localStorage
+        await page.evaluate(() => {
+            localStorage.clear();
+          });
+
+        const fileInput = page.locator('input[type="file"].hidden');
+        await fileInput.setInputFiles([
+            "./test-data/CR000000.dcm",
+            "./test-data/CR000001.dcm",
+        ]);
+
+        const promptText = page.locator(".my-4").first();
+        await expect(promptText).toBeVisible();
+
+        const noButton = page.locator("button", { hasText: "No" }).first();
+        await expect(noButton).toBeVisible();
+        await noButton.click();
+
+        const currentFile = page
+            .locator("text=Currently Viewing: CR000000.dcm")
+            .first();
+        await expect(currentFile).toBeVisible();
+
+        const sidebarToggleButton = page
+            .locator('button >> svg[data-slot="icon"]')
+            .first();
+        await sidebarToggleButton.waitFor();
+        await sidebarToggleButton.click(); 
+
+        const settingsButton = page.locator('svg.size-6.cursor-pointer');
+        await settingsButton.click();
+
+        const checkbox = await page.locator('#download-option');
+        expect(checkbox).toBeChecked();
+
+        await checkbox.click();
+        await expect(checkbox).toBeChecked(); 
+
+        await browser.close();
+    });
+
+    test('should allow changing download option for non-Safari browsers', async () => {
+        // Launch a Chromium browser (non-Safari)
+        const browser = await chromium.launch();
+
+        const context = await browser.newContext();
+        await context.clearCookies();  
+
+        const page = await browser.newPage();
+        await page.goto('http://localhost:5173'); 
+
+        // clear any saved downloadOption in localStorage
+        await page.evaluate(() => {
+            localStorage.clear(); 
+          });
+
+
+        const fileInput = page.locator('input[type="file"].hidden');
+        await fileInput.setInputFiles([
+            "./test-data/CR000000.dcm",
+            "./test-data/CR000001.dcm",
+        ]);
+
+        const promptText = page.locator(".my-4").first();
+        await expect(promptText).toBeVisible();
+
+        const noButton = page.locator("button", { hasText: "No" }).first();
+        await expect(noButton).toBeVisible();
+        await noButton.click();
+
+        const currentFile = page
+            .locator("text=Currently Viewing: CR000000.dcm")
+            .first();
+        await expect(currentFile).toBeVisible();
+
+        const sidebarToggleButton = page
+            .locator('button >> svg[data-slot="icon"]')
+            .first();
+        await sidebarToggleButton.waitFor(); 
+        await sidebarToggleButton.click(); 
+
+        const settingsButton = page.locator('svg.size-6.cursor-pointer');
+        await settingsButton.click();
+
+        const checkbox = await page.locator('#download-option');
+
+        await expect(checkbox).not.toBeChecked();
+
+        await checkbox.click();
+        await expect(checkbox).toBeChecked();
+
+        await browser.close();
+    });
+});


### PR DESCRIPTION
## Describe changes
Safari blocks downloading multiple files
- detect safari and limit downloading to zip file only

## Feature/Documentation
- tests created
- tooltips updated to inform safari user of limitation

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests available - created, passed
- [ ] Infrastructure updates required? 

Issue ticket number and link
closes #151 