### PR TITLE
Edit auto anonymize Popup values 

### DIFF
--- a/src/components/Auto/AutoClean.ts
+++ b/src/components/Auto/AutoClean.ts
@@ -6,6 +6,7 @@ import {
     downloadDicomFile,
 } from "../DicomData/DownloadFuncs";
 import { CustomFile } from "../../types/FileTypes";
+import { AnonTag } from "../../types/DicomTypes";
 
 /**
  * @description format the data to be used in the tagUpdater function
@@ -45,12 +46,21 @@ export function FormatData(dicomData: any) {
  * @param files
  * @returns none
  */
-export const AutoAnon = async (dicomData: any[], files: CustomFile[]) => {
+export const AutoAnon = async (dicomData: any[], files: CustomFile[], anonTags: AnonTag[]) => {
    
     const newFiles: any = [];
 
     dicomData.forEach((dicom: any, index: number) => {
         const formatedData = FormatData(dicom);
+
+        // Update the formatted data with the new values from anonTags
+        anonTags.forEach((anonTag) => {
+            const tagIndex = formatedData.findIndex((tag: any) => tag.tagId === anonTag.tagId);
+            if (tagIndex !== -1) {
+                formatedData[tagIndex].newValue = anonTag.newValue;
+            }
+        });
+
         const updatedFile = tagUpdater(dicomData[0].DicomDataSet, formatedData);
 
         newFiles.push(createFile(files[index].name, updatedFile));

--- a/src/components/DicomData/TableComponents/AnonPopup.tsx
+++ b/src/components/DicomData/TableComponents/AnonPopup.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
 import { AnonPopupProps } from '../../../types/DicomTypes';
+import { useStore } from '../../State/Store';
 
 /**
  * Confirmation popup for auto anonymized tags
@@ -7,9 +7,10 @@ import { AnonPopupProps } from '../../../types/DicomTypes';
  * @returns {JSX.Element} Popup box with list of tags to be anonymized
  */
 export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel, onUpdateTag }) => {
-    const [editingTagId, setEditingTagId] = useState<string | null>(null);
+    const editingTagId = useStore((state) => state.editingTagId);
+    const setEditingTagId = useStore((state) => state.setEditingTagId);
 
-    // edited tag is part of tags
+    // edited tag is part of tags array
     if (editingTagId !== null) {
         console.assert(tags.some(tag => tag.tagId === editingTagId), 'editingTagId should be a valid tagId');
     }

--- a/src/components/DicomData/TableComponents/AnonPopup.tsx
+++ b/src/components/DicomData/TableComponents/AnonPopup.tsx
@@ -4,13 +4,14 @@ import { useStore } from '../../State/Store';
 /**
  * Confirmation popup for auto anonymized tags
  * @param {AnonPopupProps} props - Component props
+ * @postcondition edited tag should not change to different tag (tagId)
  * @returns {JSX.Element} Popup box with list of tags to be anonymized
  */
 export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel, onUpdateTag }) => {
     const editingTagId = useStore((state) => state.editingTagId);
     const setEditingTagId = useStore((state) => state.setEditingTagId);
 
-    // edited tag is part of tags array
+    // edited tag is part of tags array (tagId did not chnange)
     if (editingTagId !== null) {
         console.assert(tags.some(tag => tag.tagId === editingTagId), 'editingTagId should be a valid tagId');
     }

--- a/src/components/DicomData/TableComponents/AnonPopup.tsx
+++ b/src/components/DicomData/TableComponents/AnonPopup.tsx
@@ -20,6 +20,12 @@ export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel,
     const handleBlur = () => {
         setEditingTagId(null);
     };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === 'Enter') {
+            handleBlur();
+        }
+    };
     
     return (
         <div className="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 flex justify-center items-center z-50">
@@ -35,7 +41,9 @@ export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel,
                                     value={tag.newValue}
                                     onChange={(event) => handleInputChange(tag.tagId, event)}
                                     onBlur={handleBlur}
+                                    onKeyDown={handleKeyDown}
                                     className="ml-2 p-1 border rounded"
+                                    style={{ backgroundColor: '#f0f0f0', color: '#333', borderColor: '#ccc' }}
                                     autoFocus
                                 />
                             ) : (

--- a/src/components/DicomData/TableComponents/AnonPopup.tsx
+++ b/src/components/DicomData/TableComponents/AnonPopup.tsx
@@ -9,6 +9,8 @@ import { AnonPopupProps } from '../../../types/DicomTypes';
 export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel, onUpdateTag }) => {
     const [editingTagId, setEditingTagId] = useState<string | null>(null);
 
+    console.assert(Array.isArray(tags), 'tags should be an array');
+
     const handleInputChange = (tagId: string, event: React.ChangeEvent<HTMLInputElement>) => {
         onUpdateTag(tagId, event.target.value);
     };

--- a/src/components/DicomData/TableComponents/AnonPopup.tsx
+++ b/src/components/DicomData/TableComponents/AnonPopup.tsx
@@ -9,7 +9,10 @@ import { AnonPopupProps } from '../../../types/DicomTypes';
 export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel, onUpdateTag }) => {
     const [editingTagId, setEditingTagId] = useState<string | null>(null);
 
-    console.assert(Array.isArray(tags), 'tags should be an array');
+    // edited tag is part of tags
+    if (editingTagId !== null) {
+        console.assert(tags.some(tag => tag.tagId === editingTagId), 'editingTagId should be a valid tagId');
+    }
 
     const handleInputChange = (tagId: string, event: React.ChangeEvent<HTMLInputElement>) => {
         onUpdateTag(tagId, event.target.value);

--- a/src/components/DicomData/TableComponents/AnonPopup.tsx
+++ b/src/components/DicomData/TableComponents/AnonPopup.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { AnonPopupProps } from '../../../types/DicomTypes';
 
 /**
@@ -6,7 +6,21 @@ import { AnonPopupProps } from '../../../types/DicomTypes';
  * @param {AnonPopupProps} props - Component props
  * @returns {JSX.Element} Popup box with list of tags to be anonymized
  */
-export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel }) => {
+export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel, onUpdateTag }) => {
+    const [editingTagId, setEditingTagId] = useState<string | null>(null);
+
+    const handleInputChange = (tagId: string, event: React.ChangeEvent<HTMLInputElement>) => {
+        onUpdateTag(tagId, event.target.value);
+    };
+
+    const handleTagClick = (tagId: string) => {
+        setEditingTagId(tagId);
+    };
+
+    const handleBlur = () => {
+        setEditingTagId(null);
+    };
+    
     return (
         <div className="fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 flex justify-center items-center z-50">
             <div className="bg-white p-5 rounded-lg text-center shadow-lg max-w-lg w-11/12 max-h-full overflow-y-auto">
@@ -14,7 +28,24 @@ export const AnonPopup: React.FC<AnonPopupProps> = ({ tags, onConfirm, onCancel 
                 <ul className="list-none p-0 mb-5">
                     {tags.map((tag, index) => (
                         <li key={index} className="mb-2 text-lg text-gray-500">
-                            <strong>{tag.tagId} ({tag.tagName})</strong>: {tag.newValue}
+                            <strong>{tag.tagId} ({tag.tagName})</strong>:
+                            {editingTagId === tag.tagId ? (
+                                <input
+                                    type="text"
+                                    value={tag.newValue}
+                                    onChange={(event) => handleInputChange(tag.tagId, event)}
+                                    onBlur={handleBlur}
+                                    className="ml-2 p-1 border rounded"
+                                    autoFocus
+                                />
+                            ) : (
+                                <span
+                                    className="ml-2 p-1 border rounded cursor-pointer"
+                                    onClick={() => handleTagClick(tag.tagId)}
+                                >
+                                    {tag.newValue}
+                                </span>
+                            )}
                         </li>
                     ))}
                 </ul>

--- a/src/components/DicomData/TableComponents/TableControls.tsx
+++ b/src/components/DicomData/TableComponents/TableControls.tsx
@@ -51,7 +51,7 @@ const TableControls: React.FC<TableControlsProps> = ({
     };
 
     const handleConfirm = async () => {
-        await AutoAnon(dicomData, files);
+        await AutoAnon(dicomData, files, anonTags);
         setShowPopup(false);
         clearData();
     };

--- a/src/components/DicomData/TableComponents/TableControls.tsx
+++ b/src/components/DicomData/TableComponents/TableControls.tsx
@@ -16,6 +16,7 @@ import { TagDictionary } from "../../../tagDictionary/dictionary";
  * @param {function(): void} props.onSave - Callback for save action
  * @param {function(): void} props.onToggleHidden - Callback for toggling hidden tags
  * @param {boolean} props.showHidden - Whether hidden tags are currently shown
+ * @precondition dicomData and files should not be empty
  * @returns {JSX.Element} The rendered controls section
  */
 const TableControls: React.FC<TableControlsProps> = ({
@@ -32,6 +33,9 @@ const TableControls: React.FC<TableControlsProps> = ({
     const setShowPopup = useStore((state) => state.setShowPopup);
 
     const tagDictionary = new TagDictionary();
+
+    console.assert(dicomData.length > 0, 'dicomData should not be empty');
+    console.assert(files.length > 0, 'files should not be empty');
 
     const handleAutoAnon = async () => {
         // format anon tags and show them

--- a/src/components/DicomData/TableComponents/TableControls.tsx
+++ b/src/components/DicomData/TableComponents/TableControls.tsx
@@ -34,6 +34,7 @@ const TableControls: React.FC<TableControlsProps> = ({
     const tagDictionary = new TagDictionary();
 
     const handleAutoAnon = async () => {
+        // format anon tags and show them
         const newTagData: AnonTag[] = FormatData(dicomData[0]).map((tag: { tagId: string; tagName: string; newValue: string; }) => ({
             tagId: tag.tagId,
             tagName: tagDictionary.lookupTagName(tag.tagId),
@@ -44,6 +45,7 @@ const TableControls: React.FC<TableControlsProps> = ({
     };
 
     const handleUpdateTag = (tagId: string, newValue: string) => {
+        // update tags after user input
         const updatedTags = anonTags.map((tag: AnonTag) =>
             tag.tagId === tagId ? { ...tag, newValue } : tag
         );
@@ -51,6 +53,7 @@ const TableControls: React.FC<TableControlsProps> = ({
     };
 
     const handleConfirm = async () => {
+        // anonymize tags
         await AutoAnon(dicomData, files, anonTags);
         setShowPopup(false);
         clearData();

--- a/src/components/DicomData/TableComponents/TableControls.tsx
+++ b/src/components/DicomData/TableComponents/TableControls.tsx
@@ -43,6 +43,13 @@ const TableControls: React.FC<TableControlsProps> = ({
         setShowPopup(true);
     };
 
+    const handleUpdateTag = (tagId: string, newValue: string) => {
+        const updatedTags = anonTags.map((tag: AnonTag) =>
+            tag.tagId === tagId ? { ...tag, newValue } : tag
+        );
+        setTags(updatedTags);
+    };
+
     const handleConfirm = async () => {
         await AutoAnon(dicomData, files);
         setShowPopup(false);
@@ -77,7 +84,9 @@ const TableControls: React.FC<TableControlsProps> = ({
                 <AnonPopup 
                     tags={anonTags} 
                     onConfirm={handleConfirm} 
-                    onCancel={handleCancel} />
+                    onCancel={handleCancel}
+                    onUpdateTag={handleUpdateTag}
+                />
             )}
         </div>
     );

--- a/src/components/State/Store.tsx
+++ b/src/components/State/Store.tsx
@@ -53,6 +53,9 @@ type Store = {
     showPopup: boolean;
     setShowPopup: (show: boolean) => void;
 
+    editingTagId: string | null;
+    setEditingTagId: (id: string | null) => void;
+
     clearData: () => void;
 };
 
@@ -135,6 +138,9 @@ export const useStore = create<Store>((set) => ({
 
     showPopup: false,
     setShowPopup: (show) => set({ showPopup: show }),
+
+    editingTagId: null,
+    setEditingTagId: (id) => set({ editingTagId: id }),
 
     clearData: () => {
         set({ newTagValues: [] });

--- a/src/types/DicomTypes.d.ts
+++ b/src/types/DicomTypes.d.ts
@@ -183,7 +183,7 @@ export interface AnonTag {
 /**
  * Props for the AnonPopup component
  * @interface {Object} AnonPopupProps
- * @property {Array<AnonTag> tags - List of tags to be anonymized
+ * @property {Array<AnonTag>} tags - List of tags to be anonymized
  * @property {function(): void} onConfirm - Callback function for confirming the anonymization
  * @property {function(): void} onCancel - Callback function for canceling the anonymization
  */
@@ -191,4 +191,5 @@ export interface AnonPopupProps {
     tags: AnonTag[];
     onConfirm: () => void;
     onCancel: () => void;
+    onUpdateTag: (tagId: string, newValue: string) => void;
 }

--- a/tests/jest/unitTest/AnonPopup.test.tsx
+++ b/tests/jest/unitTest/AnonPopup.test.tsx
@@ -53,4 +53,17 @@ describe('AnonPopup', () => {
         expect(onUpdateTag).toHaveBeenCalledWith('X00100010', 'General Aladeen');
     });
 
+    // ***** UNIT TEST edits tag value on Enter *****
+    test('edits tag value on Enter', () => {
+        const onUpdateTag = jest.fn();
+        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={jest.fn()} onUpdateTag={onUpdateTag} />);
+
+        fireEvent.click(screen.getByText('John Doe'));
+        const input = screen.getByDisplayValue('John Doe');
+        fireEvent.change(input, { target: { value: 'General Aladeen' } });
+        fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+        expect(onkeydown).toHaveBeenCalledTimes(1);
+        expect(onUpdateTag).toHaveBeenCalledWith('X00100010', 'General Aladeen');
+    });
+
 });

--- a/tests/jest/unitTest/AnonPopup.test.tsx
+++ b/tests/jest/unitTest/AnonPopup.test.tsx
@@ -10,7 +10,8 @@ describe('AnonPopup', () => {
     // ***** UNIT TEST onConfirm called on OK pressed *****
     test('calls onConfirm when OK button is clicked', () => {
         const onConfirm = jest.fn();
-        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={jest.fn()} />);
+        const onUpdateTag = jest.fn();
+        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={jest.fn()} onUpdateTag={onUpdateTag}/>);
 
         fireEvent.click(screen.getByText('OK'));
         expect(onConfirm).toHaveBeenCalledTimes(1);
@@ -19,7 +20,8 @@ describe('AnonPopup', () => {
     // ***** UNIT TEST onCancel called on Cancel pressed *****
     test('calls onCancel when Cancel button is clicked', () => {
         const onCancel = jest.fn();
-        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={onCancel} />);
+        const onUpdateTag = jest.fn();
+        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={onCancel} onUpdateTag={onUpdateTag}/>);
 
         fireEvent.click(screen.getByText('Cancel'));
         expect(onCancel).toHaveBeenCalledTimes(1);
@@ -27,15 +29,28 @@ describe('AnonPopup', () => {
 
     // ***** UNIT TEST renders the popup with tags *****
     test('renders the popup with tags', () => {
-        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={jest.fn()} />);
+        const onUpdateTag = jest.fn();
+        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={jest.fn()} onUpdateTag={onUpdateTag} />);
 
         // title of popup
         expect(screen.getByText('Tags to be Anonymized')).toBeInTheDocument();
 
         // checks list items (li elements) in popup
         const listItems = screen.getAllByRole("listitem");
-        expect(listItems[0]).toHaveTextContent("X00100010 (PatientName): John Doe");
-        expect(listItems[1]).toHaveTextContent("X00100020 (PatientID): 123456");
+        expect(listItems[0]).toHaveTextContent("X00100010 (PatientName):John Doe");
+        expect(listItems[1]).toHaveTextContent("X00100020 (PatientID):123456");
+    });
+
+    // ***** UNIT TEST allows editing a tag value *****
+    test('allows editing a tag value', () => {
+        const onUpdateTag = jest.fn();
+        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={jest.fn()} onUpdateTag={onUpdateTag} />);
+
+        fireEvent.click(screen.getByText('John Doe'));
+        const input = screen.getByDisplayValue('John Doe');
+        expect(input).toBeInTheDocument();
+        fireEvent.change(input, { target: { value: 'General Aladeen' } });
+        expect(onUpdateTag).toHaveBeenCalledWith('X00100010', 'General Aladeen');
     });
 
 });

--- a/tests/jest/unitTest/AnonPopup.test.tsx
+++ b/tests/jest/unitTest/AnonPopup.test.tsx
@@ -1,17 +1,29 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
 import { AnonPopup } from '../../../src/components/DicomData/TableComponents/AnonPopup';
 
 const mockTags = [
     { tagId: 'X00100010', tagName: 'PatientName', newValue: 'John Doe' },
     { tagId: 'X00100020', tagName: 'PatientID', newValue: '123456' },
+    { tagId: 'X00000001', tagName: 'Cool Guy Levels', newValue: 'Off the charts' },
+    { tagId: 'X00000002', tagName: 'some fancy value', newValue: '0987654321' },
+    { tagId: 'X00000003', tagName: 'Hydration', newValue: 'Sahara+Gobix10' },
 ];
 
+let onConfirm: jest.Mock;
+let onCancel: jest.Mock;
+let onUpdateTag: jest.Mock;
+
 describe('AnonPopup', () => {
+    beforeEach(() => {
+        cleanup();
+        onConfirm = jest.fn();
+        onCancel = jest.fn();
+        onUpdateTag = jest.fn();
+    });
+
     // ***** UNIT TEST onConfirm called on OK pressed *****
     test('calls onConfirm when OK button is clicked', () => {
-        const onConfirm = jest.fn();
-        const onUpdateTag = jest.fn();
-        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={jest.fn()} onUpdateTag={onUpdateTag}/>);
+        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={onCancel} onUpdateTag={onUpdateTag}/>);
 
         fireEvent.click(screen.getByText('OK'));
         expect(onConfirm).toHaveBeenCalledTimes(1);
@@ -19,9 +31,7 @@ describe('AnonPopup', () => {
 
     // ***** UNIT TEST onCancel called on Cancel pressed *****
     test('calls onCancel when Cancel button is clicked', () => {
-        const onCancel = jest.fn();
-        const onUpdateTag = jest.fn();
-        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={onCancel} onUpdateTag={onUpdateTag}/>);
+        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={onCancel} onUpdateTag={onUpdateTag}/>);
 
         fireEvent.click(screen.getByText('Cancel'));
         expect(onCancel).toHaveBeenCalledTimes(1);
@@ -29,8 +39,7 @@ describe('AnonPopup', () => {
 
     // ***** UNIT TEST renders the popup with tags *****
     test('renders the popup with tags', () => {
-        const onUpdateTag = jest.fn();
-        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={jest.fn()} onUpdateTag={onUpdateTag} />);
+        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={onCancel} onUpdateTag={onUpdateTag} />);
 
         // title of popup
         expect(screen.getByText('Tags to be Anonymized')).toBeInTheDocument();
@@ -39,12 +48,14 @@ describe('AnonPopup', () => {
         const listItems = screen.getAllByRole("listitem");
         expect(listItems[0]).toHaveTextContent("X00100010 (PatientName):John Doe");
         expect(listItems[1]).toHaveTextContent("X00100020 (PatientID):123456");
+        expect(listItems[2]).toHaveTextContent("X00000001 (Cool Guy Levels):Off the charts");
+        expect(listItems[3]).toHaveTextContent("X00000002 (some fancy value):0987654321");
+        expect(listItems[4]).toHaveTextContent("X00000003 (Hydration):Sahara+Gobix10");
     });
 
-    // ***** UNIT TEST allows editing a tag value *****
+    // // ***** UNIT TEST allows editing a tag value *****
     test('allows editing a tag value', () => {
-        const onUpdateTag = jest.fn();
-        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={jest.fn()} onUpdateTag={onUpdateTag} />);
+        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={onCancel} onUpdateTag={onUpdateTag} />);
 
         fireEvent.click(screen.getByText('John Doe'));
         const input = screen.getByDisplayValue('John Doe');
@@ -55,15 +66,23 @@ describe('AnonPopup', () => {
 
     // ***** UNIT TEST edits tag value on Enter *****
     test('edits tag value on Enter', () => {
-        const onUpdateTag = jest.fn();
-        render(<AnonPopup tags={mockTags} onConfirm={jest.fn()} onCancel={jest.fn()} onUpdateTag={onUpdateTag} />);
+        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={onCancel} onUpdateTag={onUpdateTag} />);
 
-        fireEvent.click(screen.getByText('John Doe'));
-        const input = screen.getByDisplayValue('John Doe');
-        fireEvent.change(input, { target: { value: 'General Aladeen' } });
+        fireEvent.click(screen.getByText('Off the charts'));
+        const input = screen.getByDisplayValue('Off the charts');
+        fireEvent.change(input, { target: { value: 'only 2' } });
         fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-        expect(onkeydown).toHaveBeenCalledTimes(1);
-        expect(onUpdateTag).toHaveBeenCalledWith('X00100010', 'General Aladeen');
+        expect(onUpdateTag).toHaveBeenCalledWith('X00000001', 'only 2');
+    });
+
+    // // ***** UNIT TEST calls handleBlur on input blur *****
+    test('calls handleBlur on input blur, and input field gone', () => {
+        render(<AnonPopup tags={mockTags} onConfirm={onConfirm} onCancel={onCancel} onUpdateTag={onUpdateTag} />);
+
+        fireEvent.click(screen.getByText('0987654321'));
+        const input = screen.getByDisplayValue('0987654321');
+        fireEvent.blur(input);
+        expect(screen.queryByDisplayValue('0987654321')).not.toBeInTheDocument();
     });
 
 });


### PR DESCRIPTION
User can choose what values they want for auto anonymizing by editing them before submitting OK in the case they don't like the default values.
 
- [x] I have performed a self-review of my code
- [x] Unit tests available - passed
- [x] Performed manual walkthroughs to ensure functionality