### PR TITLE
Fixed filename doesn't align with displayed data bug

### DIFF
--- a/src/components/FileHandling/FileUploader.tsx
+++ b/src/components/FileHandling/FileUploader.tsx
@@ -33,24 +33,6 @@ const FileUploader: React.FC<FileUploaderProps> = ({
      * @param fileArray - Array of files
      * Processes files
      */
-    // const processFiles = (fileArray: File[]) => {
-    //     const dicomDataArray: any[] = [];
-
-    //     fileArray.forEach((file) => {
-    //         parseDicomFile(file)
-    //             .then((dicomData) => {
-    //                 dicomDataArray.push(dicomData);
-    //                 if (dicomDataArray.length === fileArray.length) {
-    //                     onFileUpload(fileArray, dicomDataArray);
-    //                 }
-    //             })
-    //             .catch((error) => {
-    //                 onFileUpload((fileArray = []), dicomDataArray);
-    //                 toggleModal();
-    //                 logger.error(error);
-    //             });
-    //     });
-    // };
     const processFiles = (fileArray: File[]) => {
         clearData();
         loading(true);


### PR DESCRIPTION
Filename doesn't align with parsed data displayed on table due to Promises. Some files get parsed faster than others which changed the order of files pushed to dicomDataArray. Fixed by using Promise.all to wait for all promises to resolve.