### PR TITLE
add filename that fails to parse error modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,9 @@ export const App: React.FC = () => {
 
     const clearData = useStore((state) => state.clearData);
 
+    const fileParseError = useStore((state) => state.fileParseErrorFileNames);
+    const setFileParseError = useStore((state) => state.setFileParseErrorFileNames);
+
     const [deferredPrompt, setDeferredPrompt] = useState<any>(null);
 
     const sidebarRef = useRef<HTMLDivElement>(null);
@@ -257,9 +260,9 @@ export const App: React.FC = () => {
 
                 <Modal
                     isOpen={showErrorModal}
-                    onClose={() => setShowErrorModal(false)}
+                    onClose={() => {setShowErrorModal(false); setFileParseError([])}}
                     title="Error"
-                    text="File isn't a valid DICOM file."
+                    text={`File ${fileParseError} isn't a valid DICOM file.`}
                 />
 
                 {sidebarVisible && (

--- a/src/components/FileHandling/FileUploader.tsx
+++ b/src/components/FileHandling/FileUploader.tsx
@@ -3,6 +3,7 @@ import { useDropzone } from "react-dropzone";
 import { parseDicomFile } from "../DicomData/DicomParserUtils.ts";
 import { FileUploaderProps } from "../../types/FileTypes.ts";
 import logger from "../utils/Logger";
+import { useStore } from "@components/State/Store.tsx";
 
 /**
  *
@@ -15,6 +16,8 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
     clearData,
     toggleModal,
 }) => {
+    const setFileParseError = useStore((state) => state.setFileParseErrorFileNames);
+    const fileParseError = useStore((state) => state.fileParseErrorFileNames);
     /**
      *
      * @param e - Change event
@@ -41,6 +44,7 @@ export const FileUploader: React.FC<FileUploaderProps> = ({
         const promises = fileArray.map((file) =>
             parseDicomFile(file).catch((error) => {
                 // If any file fails, clear everything and trigger modal
+                setFileParseError([...fileParseError, file.name]);
                 logger.error(error);
                 toggleModal();
                 return null; // Ensure failed files do not break Promise.all

--- a/src/components/State/Store.tsx
+++ b/src/components/State/Store.tsx
@@ -57,6 +57,9 @@ type Store = {
     setHideTagNumber: (hide: boolean) => void;
 
     clearData: () => void;
+
+    fileParseErrorFileNames: string[];
+    setFileParseErrorFileNames: (fileNames: string[]) => void;
 };
 
 export const useStore = create<Store>((set) => ({
@@ -151,4 +154,7 @@ export const useStore = create<Store>((set) => ({
         set({ sidebarVisible: false });
         set({ series: false });
     },
+
+    fileParseErrorFileNames: [] as string[],
+    setFileParseErrorFileNames: (fileNames) => set({ fileParseErrorFileNames: fileNames }),
 }));


### PR DESCRIPTION
## Issue
File name isn't shown when a parsing error occurs
- user doesn't know what file is issue when uploading many files

## Fix
Add file name to error modal

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests available

closes #143 