### PR TITLE
auto anonymize tags based on current file, not just first file

### DIFF
--- a/src/Features/AutoAnonymize/Functions/AutoClean.ts
+++ b/src/Features/AutoAnonymize/Functions/AutoClean.ts
@@ -67,6 +67,7 @@ export const AutoAnon = async (
 
     try {
         setLoading(true);
+
         dicomData.forEach((dicom: any, index: number) => {
             const formattedData = FormatData(dicom, tagsToAnon);
 
@@ -81,7 +82,7 @@ export const AutoAnon = async (
             });
 
             const updatedFile = tagUpdater(
-                dicomData[0].DicomDataSet,
+                dicom.DicomDataSet,
                 formattedData
             );
 


### PR DESCRIPTION
## Issue
When uploading files with different set of tags, auto anon fails due to basing updates on first file

## Fix
Change so update tags based on current file being updated

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests available

## Comment 
Bug party