### PR TITLE
Fix/nested tags search

### DIFF
--- a/src/Hooks/useFilteredRows.ts
+++ b/src/Hooks/useFilteredRows.ts
@@ -1,55 +1,173 @@
 import { useMemo } from "react";
 import logger from "@logger/Logger";
 
-/**
- * Custom hook for filtering DICOM table rows
- * @function
- * @precondition useFilteredRows hook expects the following parameters
- * @postcondition Returns filtered array of table rows
- * @param {TableRow[]} rows - Array of table rows to filter
- * @param {string} searchTerm - Current search term
- * @returns {TableRow[]} Filtered array of table rows
- */
 export const useFilteredRows = (rows: any[], searchTerm: string) => {
     logger.debug(`Filtering rows with search term: ${searchTerm}`);
     logger.debug(`Rows length: ${rows.length}`);
 
     const lowerSearchTerm = searchTerm.toLowerCase();
 
-    return useMemo(
-        () =>
-            rows.filter((row) => {
-                const tagId = (row.tagId ?? "").toString().toLowerCase();
-                const tagName = (row.tagName ?? "").toString().toLowerCase();
+    const filterNestedTags = (value: any): any => {
+        if (!value) return [];
 
-                const matchesTag =
-                    tagId.includes(lowerSearchTerm) ||
-                    tagName.includes(lowerSearchTerm);
+        // SQ sequences — array of items
+        if (Array.isArray(value)) {
+            const filteredItems = value
+                .map((item: any) => {
+                    if (!item?.tags) return null;
 
-                const matchesNested =
-                    Array.isArray(row.value) &&
-                    row.value.some((nestedRow: any) => {
-                        const nestedTagId = (nestedRow?.tagId ?? "")
+                    const filteredTags = Object.values(item.tags).filter(
+                        (nestedRow: any) => {
+                            const tagId = (nestedRow.tagId ?? "")
+                                .toString()
+                                .toLowerCase();
+                            const tagName = (nestedRow.tagName ?? "")
+                                .toString()
+                                .toLowerCase();
+                            const val = (nestedRow.value ?? "")
+                                .toString()
+                                .toLowerCase();
+
+                            return (
+                                tagId.includes(lowerSearchTerm) ||
+                                tagName.includes(lowerSearchTerm) ||
+                                val.includes(lowerSearchTerm) ||
+                                matchesNestedTags(nestedRow.value)
+                            );
+                        }
+                    );
+
+                    if (filteredTags.length > 0) {
+                        return {
+                            tags: Object.fromEntries(
+                                (
+                                    filteredTags as Array<{
+                                        tagId: string;
+                                        tagName?: string;
+                                        value?: any;
+                                    }>
+                                ).map((tag) => [tag.tagId, tag])
+                            ),
+                        };
+                    }
+                    return null;
+                })
+                .filter((item: any) => item !== null);
+
+            return filteredItems;
+        }
+
+        // single nested object
+        if (typeof value === "object" && value.tags) {
+            const filteredTags = Object.values(value.tags).filter(
+                (nestedRow: any) => {
+                    const tagId = (nestedRow.tagId ?? "")
+                        .toString()
+                        .toLowerCase();
+                    const tagName = (nestedRow.tagName ?? "")
+                        .toString()
+                        .toLowerCase();
+                    const val = (nestedRow.value ?? "")
+                        .toString()
+                        .toLowerCase();
+
+                    return (
+                        tagId.includes(lowerSearchTerm) ||
+                        tagName.includes(lowerSearchTerm) ||
+                        val.includes(lowerSearchTerm) ||
+                        matchesNestedTags(nestedRow.value)
+                    );
+                }
+            );
+
+            if (filteredTags.length > 0) {
+                return {
+                    tags: Object.fromEntries(
+                        filteredTags.map((tag: any) => [tag.tagId, tag])
+                    ),
+                };
+            }
+        }
+
+        return null;
+    };
+
+    const matchesNestedTags = (value: any): boolean => {
+        if (!value) return false;
+
+        if (Array.isArray(value)) {
+            return value.some((item) => {
+                if (item?.tags) {
+                    return Object.values(item.tags).some((nestedRow: any) => {
+                        const tagId = (nestedRow.tagId ?? "")
                             .toString()
                             .toLowerCase();
-                        const nestedTagName = (nestedRow?.tagName ?? "")
+                        const tagName = (nestedRow.tagName ?? "")
                             .toString()
                             .toLowerCase();
+                        const val = (nestedRow.value ?? "")
+                            .toString()
+                            .toLowerCase();
+
                         return (
-                            nestedTagId.includes(lowerSearchTerm) ||
-                            nestedTagName.includes(lowerSearchTerm)
+                            tagId.includes(lowerSearchTerm) ||
+                            tagName.includes(lowerSearchTerm) ||
+                            val.includes(lowerSearchTerm) ||
+                            matchesNestedTags(nestedRow.value)
                         );
                     });
+                }
+                return false;
+            });
+        }
 
-                const matchesValue =
-                    !Array.isArray(row.value) &&
-                    (row.value ?? "")
-                        .toString()
-                        .toLowerCase()
-                        .includes(lowerSearchTerm);
+        if (typeof value === "object" && value.tags) {
+            return Object.values(value.tags).some((nestedRow: any) => {
+                const tagId = (nestedRow.tagId ?? "").toString().toLowerCase();
+                const tagName = (nestedRow.tagName ?? "")
+                    .toString()
+                    .toLowerCase();
+                const val = (nestedRow.value ?? "").toString().toLowerCase();
 
-                return matchesTag || matchesNested || matchesValue;
-            }),
+                return (
+                    tagId.includes(lowerSearchTerm) ||
+                    tagName.includes(lowerSearchTerm) ||
+                    val.includes(lowerSearchTerm) ||
+                    matchesNestedTags(nestedRow.value)
+                );
+            });
+        }
+
+        return false;
+    };
+
+    return useMemo(
+        () =>
+            rows
+                .map((row) => {
+                    const tagId = (row.tagId ?? "").toLowerCase();
+                    const tagName = (row.tagName ?? "").toLowerCase();
+                    const valueStr = (row.value ?? "").toString().toLowerCase();
+
+                    const matchesDirect =
+                        tagId.includes(lowerSearchTerm) ||
+                        tagName.includes(lowerSearchTerm) ||
+                        valueStr.includes(lowerSearchTerm);
+
+                    const nestedMatches = matchesNestedTags(row.value);
+                    const filteredNestedValue = nestedMatches
+                        ? filterNestedTags(row.value)
+                        : null;
+
+                    if (matchesDirect) {
+                        return row;
+                    } else if (nestedMatches && filteredNestedValue) {
+                        return { ...row, value: filteredNestedValue };
+                    }
+
+                    return null;
+                })
+                .filter(Boolean),
         [rows, searchTerm]
     );
 };

--- a/src/Hooks/useFilteredRows.ts
+++ b/src/Hooks/useFilteredRows.ts
@@ -1,6 +1,15 @@
 import { useMemo } from "react";
 import logger from "@logger/Logger";
 
+/**
+ * Custom hook for filtering DICOM table rows
+ * @function
+ * @precondition useFilteredRows hook expects the following parameters
+ * @postcondition Returns filtered array of table rows
+ * @param {TableRow[]} rows - Array of table rows to filter
+ * @param {string} searchTerm - Current search term
+ * @returns {TableRow[]} Filtered array of table rows
+ */
 export const useFilteredRows = (rows: any[], searchTerm: string) => {
     logger.debug(`Filtering rows with search term: ${searchTerm}`);
     logger.debug(`Rows length: ${rows.length}`);

--- a/src/Hooks/useFilteredRows.ts
+++ b/src/Hooks/useFilteredRows.ts
@@ -21,6 +21,8 @@ export const useFilteredRows = (rows: any[], searchTerm: string) => {
 
         // SQ sequences — array of items
         if (Array.isArray(value)) {
+            logger.debug("Filtering nested array of sequence items");
+
             const filteredItems = value
                 .map((item: any) => {
                     if (!item?.tags) return null;
@@ -68,6 +70,8 @@ export const useFilteredRows = (rows: any[], searchTerm: string) => {
 
         // single nested object
         if (typeof value === "object" && value.tags) {
+            logger.debug("Filtering single nested object with tags");
+            
             const filteredTags = Object.values(value.tags).filter(
                 (nestedRow: any) => {
                     const tagId = (nestedRow.tagId ?? "")


### PR DESCRIPTION
## Issue
The nested tags are unsearchable using the search tool in the app

## Fix
- Updated useFilteredRows hook to recursively search and filter nested sequence tags
- Parent sequence tag is shown  if nested tags match the search term
- Only matching nested tags are rendered under the parent tag
- Manually tested

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests available? Manually tested

Finished #262 