### PR TITLE
ensure loading screen is shown/updated while processing files

### DIFF
--- a/src/Features/AutoAnonymize/Components/AutoConfirmPanel.tsx
+++ b/src/Features/AutoAnonymize/Components/AutoConfirmPanel.tsx
@@ -53,6 +53,11 @@ export const SidePanel = () => {
     const handleAutoAnon = async () => {
         logger.debug("Auto Anonymizing tags");
 
+        setLoading(true);
+        setLoadingMsg("Anonymizing tags...");
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
         await AutoAnon(dicomData, files, tags, tagsToAnon, fileStructure);
 
         clearData();
@@ -108,8 +113,6 @@ export const SidePanel = () => {
             <div className="mb-4 flex justify-around">
                 <button
                     onClick={() => {
-                        setLoading(true);
-                        setLoadingMsg("Anonymizing tags...");
                         handleAutoAnon();
                     }}
                     className="rounded-full bg-success px-6 py-2.5 text-sm font-medium text-primary-content shadow-md transition-all duration-200 hover:scale-105 hover:shadow-lg disabled:bg-base-300 disabled:hover:scale-100"

--- a/src/Features/AutoAnonymize/Functions/AutoClean.ts
+++ b/src/Features/AutoAnonymize/Functions/AutoClean.ts
@@ -72,10 +72,17 @@ export const AutoAnon = async (
     logger.debug("Auto anonymizing DICOM files");
 
     try {
-        dicomData.forEach((dicom: any, index: number) => {
+        // Process files one by one using a for loop and await
+        for (let index = 0; index < dicomData.length; index++) {
+            const dicom = dicomData[index];
+
+            // Update loading message
             setLoadingMsg(
                 `Anonymizing file ${index + 1} of ${dicomData.length}`
             );
+
+            // Force UI update before continuing
+            await new Promise((resolve) => setTimeout(resolve, 0));
 
             const formattedData = FormatData(dicom, tagsToAnon);
 
@@ -119,9 +126,12 @@ export const AutoAnon = async (
             fileWithPath.path = filePath;
 
             structuredFiles.push(fileWithPath);
-        });
+        }
 
         setLoadingMsg("Creating ZIP file");
+        // Force UI update before continuing
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
         const zipFile = await createZipFromFiles(structuredFiles);
 
         downloadDicomFile({ name: "anonymized_dicoms.zip", content: zipFile });


### PR DESCRIPTION
## Issue
Loading screen isn't shown during file update processing

## Fix
Use promises and resolves to ensure loading screen gets updated during file update processing

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests available - manual tests, not sure about how to create auto tests

Issue ticket number and link
Bug party