### PR TITLE
Fix: Reduce anys in TagUpdater

### DIFF
--- a/src/DataFunctions/DicomData/TagUpdater.ts
+++ b/src/DataFunctions/DicomData/TagUpdater.ts
@@ -93,7 +93,7 @@ export function tagUpdater(dicomData: dicomParser.DataSet, newTagData: any) {
     const newTags: InsertTag[] = [];
     const newDicomData = dicomData.byteArray;
     const filteredTags = newTagData;
-    let data: any;
+    let data;
 
     if (filteredTags.length === 0) {
         return newDicomData;
@@ -169,7 +169,7 @@ export function tagUpdater(dicomData: dicomParser.DataSet, newTagData: any) {
  * @param {string} tag.value - The value to add for this tag
  * @returns {Uint8Array} Updated byte array with the tag appended
  */
-function addTag(dicomData: any, tag: InsertTag) {
+function addTag(dicomData: any, tag: InsertTag): Uint8Array<ArrayBuffer> {
     const tagIdByte = new Uint8Array(groupLen + elementLen);
     const group = parseInt(tag.tagId.slice(1, 5), 16);
     const element = parseInt(tag.tagId.slice(5), 16);
@@ -198,7 +198,7 @@ function addTag(dicomData: any, tag: InsertTag) {
  * @param {Uint8Array} newtag - Byte array representation of the tag to insert
  * @returns {Uint8Array} Updated byte array with the tag inserted
  */
-function insertTag(dicomData: any, tagToAdd: InsertTag, newtag: any) {
+function insertTag(dicomData: any, tagToAdd: InsertTag, newtag: any): Uint8Array<ArrayBuffer> {
     const dicomByteArray = dicomData.byteArray;
 
     const first = dicomByteArray.slice(0, tagToAdd.dataOffSet - 8);
@@ -226,7 +226,7 @@ function insertTag(dicomData: any, tagToAdd: InsertTag, newtag: any) {
  * @param {number} tagToRemove.dataOffSet - The data offset position of the tag
  * @returns {Uint8Array} Byte array with the tag removed
  */
-function removeTag(dicomData: any, tagToRemove: InsertTag) {
+function removeTag(dicomData: any, tagToRemove: InsertTag): Uint8Array<ArrayBuffer> {
     const dicomByteArray = dicomData.byteArray;
 
     const first = dicomByteArray.slice(0, tagToRemove.dataOffSet - 8);
@@ -251,7 +251,7 @@ function removeTag(dicomData: any, tagToRemove: InsertTag) {
  * @param {Uint8Array} buffer2 - Second byte array
  * @returns {Uint8Array} New concatenated byte array containing the content of both input arrays
  */
-function concatBuffers(bufffer1: Uint8Array, buffer2: Uint8Array): Uint8Array {
+function concatBuffers(bufffer1: Uint8Array, buffer2: Uint8Array): Uint8Array<ArrayBuffer> {
     const concatedBuffer = new Uint8Array(bufffer1.length + buffer2.length);
     concatedBuffer.set(bufffer1);
     concatedBuffer.set(buffer2, bufffer1.length);
@@ -496,7 +496,7 @@ function getValueLength(tag: InsertTag) {
  * @returns {Array<Object>} Array of tag objects that match the specified fileName
  */
 export function getSingleFileTagEdits(newTags: TableUpdateData[], fileName: string): TableUpdateData[] {
-    return newTags.filter((tag: any) => tag.fileName === fileName);
+    return newTags.filter((tag: TableUpdateData) => tag.fileName === fileName);
 }
 
 /**

--- a/src/DataFunctions/DicomData/TagUpdater.ts
+++ b/src/DataFunctions/DicomData/TagUpdater.ts
@@ -63,6 +63,7 @@ const lengthOffset = 6;
 
 import dicomParser from "dicom-parser";
 import logger from "@logger/Logger";
+import { TableUpdateData } from "@dicom//Types/DicomTypes";
 
 /**
  * Update the tags in a DICOM file
@@ -484,7 +485,7 @@ function getValueLength(tag: any) {
  * @param {string} fileName - The file name to filter tags by
  * @returns {Array<Object>} Array of tag objects that match the specified fileName
  */
-export function getSingleFileTagEdits(newTags: any, fileName: string) {
+export function getSingleFileTagEdits(newTags: TableUpdateData[], fileName: string): TableUpdateData[] {
     return newTags.filter((tag: any) => tag.fileName === fileName);
 }
 

--- a/src/DataFunctions/DicomData/TagUpdater.ts
+++ b/src/DataFunctions/DicomData/TagUpdater.ts
@@ -10,6 +10,10 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
+import dicomParser from "dicom-parser";
+import logger from "@logger/Logger";
+import { TableUpdateData, InsertTag } from "@dicom//Types/DicomTypes";
+
 //mset to turn on console logs for debugging
 const DEBUG = false;
 
@@ -60,20 +64,6 @@ const headerLen = 8;
 const longHeaderLen = 12;
 const vrOffset = 4;
 const lengthOffset = 6;
-
-import dicomParser from "dicom-parser";
-import logger from "@logger/Logger";
-import { TableUpdateData } from "@dicom//Types/DicomTypes";
-
-export type InsertTag = {
-    tagId: string;
-    newValue: string;
-    vr: string;
-    dataOffSet: number;
-    length: number;
-    delete: boolean;
-    add: boolean;
-}
 
 /**
  * Update the tags in a DICOM file

--- a/src/DataFunctions/DicomData/TagUpdater.ts
+++ b/src/DataFunctions/DicomData/TagUpdater.ts
@@ -93,7 +93,7 @@ export function tagUpdater(dicomData: dicomParser.DataSet, newTagData: any) {
     const newTags: InsertTag[] = [];
     const newDicomData = dicomData.byteArray;
     const filteredTags = newTagData;
-    let data;
+    let data: any;
 
     if (filteredTags.length === 0) {
         return newDicomData;
@@ -169,7 +169,7 @@ export function tagUpdater(dicomData: dicomParser.DataSet, newTagData: any) {
  * @param {string} tag.value - The value to add for this tag
  * @returns {Uint8Array} Updated byte array with the tag appended
  */
-function addTag(dicomData: any, tag: InsertTag): Uint8Array<ArrayBuffer> {
+function addTag(dicomData: any, tag: InsertTag): Uint8Array {
     const tagIdByte = new Uint8Array(groupLen + elementLen);
     const group = parseInt(tag.tagId.slice(1, 5), 16);
     const element = parseInt(tag.tagId.slice(5), 16);
@@ -198,7 +198,7 @@ function addTag(dicomData: any, tag: InsertTag): Uint8Array<ArrayBuffer> {
  * @param {Uint8Array} newtag - Byte array representation of the tag to insert
  * @returns {Uint8Array} Updated byte array with the tag inserted
  */
-function insertTag(dicomData: any, tagToAdd: InsertTag, newtag: any): Uint8Array<ArrayBuffer> {
+function insertTag(dicomData: any, tagToAdd: InsertTag, newtag: Uint8Array): Uint8Array {
     const dicomByteArray = dicomData.byteArray;
 
     const first = dicomByteArray.slice(0, tagToAdd.dataOffSet - 8);
@@ -226,7 +226,7 @@ function insertTag(dicomData: any, tagToAdd: InsertTag, newtag: any): Uint8Array
  * @param {number} tagToRemove.dataOffSet - The data offset position of the tag
  * @returns {Uint8Array} Byte array with the tag removed
  */
-function removeTag(dicomData: any, tagToRemove: InsertTag): Uint8Array<ArrayBuffer> {
+function removeTag(dicomData: any, tagToRemove: InsertTag): Uint8Array {
     const dicomByteArray = dicomData.byteArray;
 
     const first = dicomByteArray.slice(0, tagToRemove.dataOffSet - 8);
@@ -251,7 +251,7 @@ function removeTag(dicomData: any, tagToRemove: InsertTag): Uint8Array<ArrayBuff
  * @param {Uint8Array} buffer2 - Second byte array
  * @returns {Uint8Array} New concatenated byte array containing the content of both input arrays
  */
-function concatBuffers(bufffer1: Uint8Array, buffer2: Uint8Array): Uint8Array<ArrayBuffer> {
+function concatBuffers(bufffer1: Uint8Array, buffer2: Uint8Array): Uint8Array {
     const concatedBuffer = new Uint8Array(bufffer1.length + buffer2.length);
     concatedBuffer.set(bufffer1);
     concatedBuffer.set(buffer2, bufffer1.length);
@@ -270,7 +270,7 @@ function concatBuffers(bufffer1: Uint8Array, buffer2: Uint8Array): Uint8Array<Ar
  * @param {boolean} littleEndian - Whether to use little endian byte ordering
  * @returns {Uint8Array} The complete tag byte array representation
  */
-function createTag(tagId: Uint8Array, tag: InsertTag, littleEndian: boolean) {
+function createTag(tagId: Uint8Array, tag: InsertTag, littleEndian: boolean): Uint8Array {
     const valueOffset =
         tag.vr in VR_with_12_bytes_header ? longHeaderLen : headerLen;
     const valueLength = getValueLength(tag);

--- a/src/DataFunctions/DicomData/TagUpdater.ts
+++ b/src/DataFunctions/DicomData/TagUpdater.ts
@@ -65,6 +65,16 @@ import dicomParser from "dicom-parser";
 import logger from "@logger/Logger";
 import { TableUpdateData } from "@dicom//Types/DicomTypes";
 
+export type InsertTag = {
+    tagId: string;
+    newValue: string;
+    vr: string;
+    dataOffSet: number;
+    length: number;
+    delete: boolean;
+    add: boolean;
+}
+
 /**
  * Update the tags in a DICOM file
  * @description Updates, adds, or removes tags in a DICOM file based on the provided tag data
@@ -80,7 +90,7 @@ import { TableUpdateData } from "@dicom//Types/DicomTypes";
  * @throws {Error} If the file update fails or produces invalid DICOM data
  */
 export function tagUpdater(dicomData: dicomParser.DataSet, newTagData: any) {
-    const newTags: any = [];
+    const newTags: InsertTag[] = [];
     const newDicomData = dicomData.byteArray;
     const filteredTags = newTagData;
     let data: any;
@@ -92,9 +102,9 @@ export function tagUpdater(dicomData: dicomParser.DataSet, newTagData: any) {
     debug("filteredTags: " + JSON.stringify(filteredTags));
 
     filteredTags.forEach((tag: any) => {
-        const insertTag = {
+        const insertTag: InsertTag = {
             tagId: tag.tagId,
-            value: tag.newValue,
+            newValue: tag.newValue,
             vr: dicomData.elements[tag.tagId.toLowerCase()]?.vr || "ST",
             dataOffSet:
                 dicomData.elements[tag.tagId.toLowerCase()]?.dataOffset || 0,
@@ -106,7 +116,7 @@ export function tagUpdater(dicomData: dicomParser.DataSet, newTagData: any) {
         debug("insertTag: " + JSON.stringify(insertTag));
     });
 
-    newTags.forEach((tag: any) => {
+    newTags.forEach((tag: InsertTag) => {
         if (tag.delete) {
             data = removeTag(dicomData, tag);
         } else if (tag.add) {
@@ -159,7 +169,7 @@ export function tagUpdater(dicomData: dicomParser.DataSet, newTagData: any) {
  * @param {string} tag.value - The value to add for this tag
  * @returns {Uint8Array} Updated byte array with the tag appended
  */
-function addTag(dicomData: any, tag: any) {
+function addTag(dicomData: any, tag: InsertTag) {
     const tagIdByte = new Uint8Array(groupLen + elementLen);
     const group = parseInt(tag.tagId.slice(1, 5), 16);
     const element = parseInt(tag.tagId.slice(5), 16);
@@ -188,7 +198,7 @@ function addTag(dicomData: any, tag: any) {
  * @param {Uint8Array} newtag - Byte array representation of the tag to insert
  * @returns {Uint8Array} Updated byte array with the tag inserted
  */
-function insertTag(dicomData: any, tagToAdd: any, newtag: any) {
+function insertTag(dicomData: any, tagToAdd: InsertTag, newtag: any) {
     const dicomByteArray = dicomData.byteArray;
 
     const first = dicomByteArray.slice(0, tagToAdd.dataOffSet - 8);
@@ -216,7 +226,7 @@ function insertTag(dicomData: any, tagToAdd: any, newtag: any) {
  * @param {number} tagToRemove.dataOffSet - The data offset position of the tag
  * @returns {Uint8Array} Byte array with the tag removed
  */
-function removeTag(dicomData: any, tagToRemove: any) {
+function removeTag(dicomData: any, tagToRemove: InsertTag) {
     const dicomByteArray = dicomData.byteArray;
 
     const first = dicomByteArray.slice(0, tagToRemove.dataOffSet - 8);
@@ -260,7 +270,7 @@ function concatBuffers(bufffer1: Uint8Array, buffer2: Uint8Array): Uint8Array {
  * @param {boolean} littleEndian - Whether to use little endian byte ordering
  * @returns {Uint8Array} The complete tag byte array representation
  */
-function createTag(tagId: Uint8Array, tag: any, littleEndian: boolean) {
+function createTag(tagId: Uint8Array, tag: InsertTag, littleEndian: boolean) {
     const valueOffset =
         tag.vr in VR_with_12_bytes_header ? longHeaderLen : headerLen;
     const valueLength = getValueLength(tag);
@@ -287,7 +297,7 @@ function createTag(tagId: Uint8Array, tag: any, littleEndian: boolean) {
         case "FD":
             newTag.set(
                 writeTypedNumber(
-                    parseInt(tag.tagValue, 10),
+                    parseInt(tag.newValue, 10),
                     "double",
                     valueLength,
                     littleEndian
@@ -298,7 +308,7 @@ function createTag(tagId: Uint8Array, tag: any, littleEndian: boolean) {
         case "FL":
             newTag.set(
                 writeTypedNumber(
-                    parseInt(tag.tagValue, 10),
+                    parseInt(tag.newValue, 10),
                     "float",
                     valueLength,
                     littleEndian
@@ -309,7 +319,7 @@ function createTag(tagId: Uint8Array, tag: any, littleEndian: boolean) {
         case "UL":
             newTag.set(
                 writeTypedNumber(
-                    parseInt(tag.tagValue, 10),
+                    parseInt(tag.newValue, 10),
                     "uint32",
                     valueLength,
                     littleEndian
@@ -320,7 +330,7 @@ function createTag(tagId: Uint8Array, tag: any, littleEndian: boolean) {
         case "US":
             newTag.set(
                 writeTypedNumber(
-                    parseInt(tag.tagValue, 10),
+                    parseInt(tag.newValue, 10),
                     "uint16",
                     valueLength,
                     littleEndian
@@ -331,7 +341,7 @@ function createTag(tagId: Uint8Array, tag: any, littleEndian: boolean) {
         case "SL":
             newTag.set(
                 writeTypedNumber(
-                    parseInt(tag.tagValue, 10),
+                    parseInt(tag.newValue, 10),
                     "int32",
                     valueLength,
                     littleEndian
@@ -342,7 +352,7 @@ function createTag(tagId: Uint8Array, tag: any, littleEndian: boolean) {
         case "SS":
             newTag.set(
                 writeTypedNumber(
-                    parseInt(tag.tagValue, 10),
+                    parseInt(tag.newValue, 10),
                     "int16",
                     valueLength,
                     littleEndian
@@ -351,14 +361,14 @@ function createTag(tagId: Uint8Array, tag: any, littleEndian: boolean) {
             );
             break;
         // case 'AT':
-        //     const atGroup = parseInt(tag.value.slice(0, 4), 16);
-        //     const atElement = parseInt(tag.value.slice(4,), 16);
+        //     const atGroup = parseInt(tag.newValue.slice(0, 4), 16);
+        //     const atElement = parseInt(tag.newValue.slice(4,), 16);
         //     newTag.set(writeTypedNumber(atGroup, 'uint16', valueLength / 2, littleEndian), valueOffset);
         //     newTag.set(writeTypedNumber(atElement, 'uint16', valueLength / 2, littleEndian), valueOffset + 2);
         //     break;
         default:
-            for (let i = 0; i < tag.value.length; i++) {
-                newTag[i + 8] = tag.value.charCodeAt(i);
+            for (let i = 0; i < tag.newValue.length; i++) {
+                newTag[i + 8] = tag.newValue.charCodeAt(i);
             }
             break;
     }
@@ -441,16 +451,16 @@ function writeVRArray(vr: string) {
  * @param {string} tag.value - The string value of the tag (for string types)
  * @returns {number} Byte length required to store the tag value according to its VR
  */
-function getValueLength(tag: any) {
-    if (tag.tagVR in NUMBERS) {
-        let value = parseInt(tag.tagValue, 10);
+function getValueLength(tag: InsertTag) {
+    if (tag.vr in NUMBERS) {
+        let value = parseInt(tag.newValue, 10);
         let byteLength = 1;
         /* tslint:disable */
         while ((value >>= 8) > 0) {
             /* tslint:enable */
             byteLength++;
         }
-        switch (tag.tagVR[1]) {
+        switch (tag.vr[1]) {
             case "S":
                 byteLength += 2 - (byteLength % 2);
                 break;
@@ -464,12 +474,12 @@ function getValueLength(tag: any) {
                 break;
         }
         return byteLength;
-    } else if (tag.tagVR === "AT") {
+    } else if (tag.vr === "AT") {
         return 4;
     } else {
-        debug("Tag value length: " + tag.value.length);
+        debug("Tag value length: " + tag.newValue.length);
 
-        return tag.value.length;
+        return tag.newValue.length;
     }
 }
 

--- a/src/DataFunctions/DicomData/UpdateAllFiles.ts
+++ b/src/DataFunctions/DicomData/UpdateAllFiles.ts
@@ -82,7 +82,7 @@ export const updateAllFiles = async (
 
         dicomData.forEach((dicom, index) => {
             const fileName = files[index].name;
-            const fileEdits = getSingleFileTagEdits(newTagValues, fileName);
+            const fileEdits: TableUpdateData[] = getSingleFileTagEdits(newTagValues, fileName);
             const isEdited = fileEdits && Object.keys(fileEdits).length > 0;
 
             const updatedFile = tagUpdater(dicom.DicomDataSet, fileEdits);

--- a/src/DataFunctions/DicomData/UpdateAllFiles.ts
+++ b/src/DataFunctions/DicomData/UpdateAllFiles.ts
@@ -82,7 +82,7 @@ export const updateAllFiles = async (
 
         dicomData.forEach((dicom, index) => {
             const fileName = files[index].name;
-            const fileEdits: TableUpdateData[] = getSingleFileTagEdits(newTagValues, fileName);
+            const fileEdits = getSingleFileTagEdits(newTagValues, fileName);
             const isEdited = fileEdits && Object.keys(fileEdits).length > 0;
 
             const updatedFile = tagUpdater(dicom.DicomDataSet, fileEdits);

--- a/src/Features/DicomTagTable/Functions/rowUtils.ts
+++ b/src/Features/DicomTagTable/Functions/rowUtils.ts
@@ -1,4 +1,5 @@
 import logger from "@logger/Logger";
+import { TableUpdateData } from "../Types/DicomTypes";
 
 /**
  * createRows function
@@ -13,7 +14,7 @@ import logger from "@logger/Logger";
 export const createRows = (
     dicomData: any,
     fileName: string,
-    newTableData: any[]
+    newTableData: TableUpdateData[]
 ) => {
     logger.debug("Creating rows for the DICOM table");
 

--- a/src/Features/DicomTagTable/Types/DicomTypes.d.ts
+++ b/src/Features/DicomTagTable/Types/DicomTypes.d.ts
@@ -201,3 +201,24 @@ export interface AnonPopupProps {
     onCancel: () => void;
     onUpdateTag: (tagId: string, newValue: string) => void;
 }
+
+/** 
+ * Dicom Tag used in TagUdater
+ * @interface {Object} InsertTag
+ * @property {string} tagId - ID of the DICOM tag
+ * @property {string} newValue - New value for the tag
+ * @property {string} vr - Value Representation of the tag
+ * @property {number} dataOffSet - Offset of the tag data
+ * @property {number} length - Length of the tag data
+ * @property {boolean} delete - Whether to delete the tag
+ * @property {boolean} add - Whether to add the tag
+ */
+export type InsertTag = {
+    tagId: string;
+    newValue: string;
+    vr: string;
+    dataOffSet: number;
+    length: number;
+    delete: boolean;
+    add: boolean;
+}


### PR DESCRIPTION
## Issue
TagUpdater was using too many anys

## Fix
Made a new type called InsertTag. Also specified return types for some functions

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests - jest tests and playwright regression test passed in container.
- [x] Any unintended results? (if so, documented? Other fixes in progress? Tickets created?)

Issue ticket number and link
part of #229 