### PR TITLE
exclude the Vite entry and root from Jest coverage

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -36,7 +36,9 @@ export default {
     collectCoverage: true,
     collectCoverageFrom: [
         "src/**/*.{ts,tsx}", //Includes all source ts codes
-        "!src/**/*.d.ts", //Exclude type declarations
+        "!src/**/*.d.ts",    //Exclude type declarations
+        "!src/main.tsx",      // Exclude Vite entry point
+        "!src/App.tsx",       // Exclude Vite root component
     ],
     coverageDirectory: "coverage",
     coverageReporters: [ "json", "text" ],


### PR DESCRIPTION
## Issue
Error pops up when run Jest coverage coz Vite

## Fix
exclude the Vite entry and root from Jest coverage

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests available? 
- [x] Any unintended results? (if so, documented? Other fixes in progress? Tickets created?)

