### PR TITLE
Fix: New tag's name from 'Add tag' showed up as "name"

### DIFF
--- a/src/Features/DicomTagTable/Functions/rowUtils.ts
+++ b/src/Features/DicomTagTable/Functions/rowUtils.ts
@@ -1,5 +1,6 @@
 import logger from "@logger/Logger";
 import { TableUpdateData } from "../Types/DicomTypes";
+import { getTagName } from "@dataFunctions/DicomData/DicomParserUtils";
 
 /**
  * createRows function
@@ -48,7 +49,7 @@ export const createRows = (
         if (tag.add && tag.fileName === fileName) {
             data.push({
                 tagId: tag.tagId,
-                tagName: "name",
+                tagName: getTagName(tag.tagId) || "Unknown",
                 value: tag.newValue,
                 hidden: false,
                 updated: false,


### PR DESCRIPTION
## Issue
When Add Tag is clicked, user puts in an id, a tag value and clicks the checkmark, the new tag at the bottom of the table had a name "name".

## Fix
Changed the name string to getting tag name from id

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] Tests available? 
- [ ] Any unintended results? (if so, documented? Other fixes in progress? Tickets created?)
Ran the jest and playwright systems tests, doesn't seem like there are any issues.